### PR TITLE
fixing minor typos and wording in the Markdown

### DIFF
--- a/transformer.ipynb
+++ b/transformer.ipynb
@@ -31,21 +31,21 @@
    "source": [
     "# Transformers\n",
     "\n",
-    "In 2017, Google Brain release a paper titled Attention is All you Need, where they departed from the traditional Seq2Seq architectures used in NLP and introduced a new kind of architecture: the transformer. As the title of their paper suggests, the transformer is based on attention mechanisms, and does not use any kind of recurrent states as in RNNs. This meant that a transformer could be trained significantly faster than a Seq2Seq model using RNNs, as sequences were no longer processed one token at a time, but rather all at once. It also significantly reduced the complexity of the models being worked with. As opposed to having complex Seq2Seq variations that can quickly become intractable, the transformer is composed of relatively straightforward matrix multiplications all the way through."
+    "In 2017, Google Brain released a paper titled *Attention is All you Need*, where they departed from the traditional Seq2Seq architectures used in NLP and introduced a new kind of architecture: the transformer. As the title of their paper suggests, the transformer is based on attention mechanisms, and does not use any kind of recurrent states as in RNNs. This meant that a transformer could be trained significantly faster than a Seq2Seq model using RNNs, as sequences were no longer processed one token at a time, but rather all at once. It also significantly reduced the complexity of the models being worked with. As opposed to having complex Seq2Seq variations that can quickly become intractable, the transformer is composed of relatively straightforward matrix multiplications all the way through."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This notebook focuses on GPT-2 style transformers, introduced by OpenAI in their paper \"Language Models are Unsupervised Multitask Learners\". The original transformer architecture used an encoder-decoder structure for sequence to sequence tasks like translation. GPT-2 and most modern transformers use only the decoder component to excel at language modeling and text generation. In this first section, we'll focus on text generation at a high level."
+    "This notebook focuses on GPT-2 style transformers, introduced by OpenAI in their paper *Language Models are Unsupervised Multitask Learners*. The original transformer architecture used an encoder-decoder structure for sequence to sequence tasks like translation. GPT-2 and most modern transformers use only the decoder component to excel at language modeling and text generation. In this first section, we'll focus on text generation at a high level."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's start with tokenization. A model's \"vocabulary\" isn't simply a list of words like we've done previously. Transformers use subword tokenization instead of full words. We can think of tokens as individual, meaninful components of language. Learning the atomic structure of language allows our model to generalize onto never-before-seen words and form more a nuanced representation of langauge.\n",
+    "Let's start with tokenization. A model's \"vocabulary\" isn't simply a list of words like we've done previously. Transformers use subword tokenization instead of full words. We can think of tokens as individual, meaningful components of language, with parts like prefixes root words (or parts of root words), suffixes, and the like. Learning the atomic structure of language allows our model to generalize onto never-before-seen words and form more a nuanced representation of language.\n",
     "\n",
     "**How do we define tokens?**\n",
     "\n",
@@ -67,7 +67,7 @@
     "\"re\"\n",
     "```\n",
     "\n",
-    "Note - you might see the character `Ġ` in front of some tokens. This is a special token that indicates that the token begins with a space. Tokens with a leading space vs not are different.\n",
+    "Note - you might see the character `Ġ` in front of some tokens. This is a special token that indicates that the token begins with a space. Tokens with a leading space and those without a leading space are different.\n",
     "\n",
     "We'll use the `AutoModelForCausalLM` and `AutoTokenizer` libraries to load in a transformer model and its tokenizer from Huggingface. (Hugging Face is an open source ML platform for sharing pretrained models, datasets, and much more!)"
    ]
@@ -1261,7 +1261,7 @@
     "* It provides context that this is the start of a sequence, which can help the model generate more appropriate text.\n",
     "* It can act as a \"rest position\" for attention heads (more on this later, when we discuss attention).\n",
     "\n",
-    "In GPT-2, the End of Sequence (EOS), Beginning of Sequence (BOS) and Padding (PAD) tokens are all the same, `<|endoftext|>` with index `50256`. This is because GPT-2 is an autoregressive model that only processes text left ot right, so it has no need to distingish between BOS and EOS tokens.\n",
+    "In GPT-2, the End of Sequence (EOS), Beginning of Sequence (BOS) and Padding (PAD) tokens are all the same, `<|endoftext|>` with index `50256`. This is because GPT-2 is an autoregressive model that only processes text left ot right, so it has no need to distinguish between BOS and EOS tokens.\n",
     "\n",
     "#### **Step 1:** Convert text to tokens\n",
     "\n",
@@ -1481,7 +1481,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Image"
+    "Image - TODO?"
    ]
   },
   {
@@ -1614,7 +1614,7 @@
     "\n",
     "`get_split_l0_heads()`\n",
     "- Loads and splits $W_Q, W_K, W_V$ in layer 0. Transformers in practice typically have their heads concatenated for more efficient computation. \n",
-    "- The GPT2 implmentation from Hugging Face has $W_Q, W_K, W_V$ combined into a single weight matrix shape `[d_model, (d_model * 3)]`. \n",
+    "- The GPT-2 implementation from Hugging Face has $W_Q, W_K, W_V$ combined into a single weight matrix shape `[d_model, (d_model * 3)]`. \n",
     "- We split the weight matrix into $W_Q, W_K, W_V$, then split those matrices further into `[d_model, n_heads, d_head]`.\n",
     "\n",
     "`get_pre_attn()`\n",
@@ -1712,7 +1712,7 @@
     "* `current_token_heads`, which attend mainly to the current token (e.g. head `0.1`)\n",
     "* `first_token_heads`, which attend mainly to the first token (e.g. heads `0.0`, although these are a bit less clear-cut than the other two)\n",
     "\n",
-    "The `prev_token_heads` and `current_token_heads` are perhaps unsurprising, because words that are close together in a sequence probably have a lot more mutual information (i.e. we could get quite far using bigram or trigram prediction).\n",
+    "The `prev_token_heads` and `current_token_heads` are perhaps unsurprising, because words that are close together in a sequence probably have a lot more mutual information than words that are far apart (i.e. we could get quite far using bigram or trigram prediction).\n",
     "\n",
     "The `first_token_heads` are a bit more surprising. The basic intuition here is that the first token in a sequence is often used as a resting or null position for heads that only sometimes activate (since our attention probabilities always have to add up to 1)."
    ]
@@ -1930,7 +1930,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's bundle everything together into a simple transformer layer. Self attention refers to the fact that our input sequence `src` attends to itself via attention!"
+    "Let's bundle everything together into a simple transformer layer. Self-attention refers to the fact that our input sequence `src` attends to itself via attention!"
    ]
   },
   {
@@ -1961,7 +1961,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Attention operates over all pairs of positions. This means it's symmetric with regards to position - the attention calculation from token 5 to token 1 and token 5 to token 2 are the same by default. We don't want this - nearby tokens should be more relevant. \n",
+    "Attention operates over all pairs of positions. This means it's invariant with regards to position - the attention calculation from token 5 to token 1 and token 5 to token 2 are the same by default. We don't want this - nearby tokens should be more relevant. \n",
     "\n",
     "`PositionalEncoding` class is a crucial component in transformer-based models. It adds positional information to input embeddings, allowing the model to understand the sequence order of inputs."
    ]
@@ -1970,7 +1970,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Our implementation of  `PositionalEncoding` class uses sine and cosine functions of different frequencies to generate unique positional embeddings for each position in the input sequence. These embeddings are then added to the input embeddings to provide positional context.\n",
+    "We want to insert some unique positional information. Our implementation of  `PositionalEncoding` class uses sine and cosine functions of different frequencies to generate these unique positional embeddings for each position in the input sequence. These embeddings are then added to the input embeddings to provide positional context.\n",
     "\n",
     "The encoding for a position `pos` and dimension `i` is given by:\n",
     "\n",


### PR DESCRIPTION
Most are spelling fixes.

"symmetric" -> "invariant" because "symmetric" refers to specific transformations (e.g. rotation, flip), but you actually mean that without positional encoding, position doesn't matter in _any_ way